### PR TITLE
Add [%s] and size to test files; these are mandatory

### DIFF
--- a/data/svd/test16.svd
+++ b/data/svd/test16.svd
@@ -6,6 +6,7 @@
     <description></description>
     <addressUnitBits>8</addressUnitBits>
     <width>16</width>
+    <size>16</size>
     <peripherals>
         <peripheral>
             <name>peripheral1</name>
@@ -61,7 +62,7 @@
             <registers>
                 <register>
                     <!-- This register is actually an array of registers. -->
-                    <name>register1</name>
+                    <name>register[%s]</name>
                     <addressOffset>0x0</addressOffset>
                     <dim>2</dim>
                     <dimIncrement>0x40</dimIncrement>

--- a/data/svd/test32.svd
+++ b/data/svd/test32.svd
@@ -6,6 +6,7 @@
     <description></description>
     <addressUnitBits>8</addressUnitBits>
     <width>32</width>
+    <size>32</size>
     <peripherals>
         <peripheral>
             <name>peripheral1</name>
@@ -61,7 +62,7 @@
             <registers>
                 <register>
                     <!-- This register is actually an array of registers. -->
-                    <name>register1</name>
+                    <name>register[%s]</name>
                     <addressOffset>0x0</addressOffset>
                     <dim>2</dim>
                     <dimIncrement>0x40</dimIncrement>

--- a/data/svd/test64.svd
+++ b/data/svd/test64.svd
@@ -6,6 +6,7 @@
     <description></description>
     <addressUnitBits>8</addressUnitBits>
     <width>64</width>
+    <size>64</size>
     <peripherals>
         <peripheral>
             <name>peripheral1</name>
@@ -61,7 +62,7 @@
             <registers>
                 <register>
                     <!-- This register is actually an array of registers. -->
-                    <name>register1</name>
+                    <name>register[%s]</name>
                     <addressOffset>0x0</addressOffset>
                     <dim>2</dim>
                     <dimIncrement>0x40</dimIncrement>

--- a/data/svd/test8.svd
+++ b/data/svd/test8.svd
@@ -6,6 +6,7 @@
     <description></description>
     <addressUnitBits>8</addressUnitBits>
     <width>8</width>
+    <size>8</size>
     <peripherals>
         <peripheral>
             <name>peripheral1</name>
@@ -54,7 +55,7 @@
             <registers>
                 <register>
                     <!-- This register is actually an array of registers. -->
-                    <name>register1</name>
+                    <name>register[%s]</name>
                     <addressOffset>0x0</addressOffset>
                     <dim>2</dim>
                     <dimIncrement>0x8</dimIncrement>

--- a/data/test.svd
+++ b/data/test.svd
@@ -6,6 +6,7 @@
     <description></description>
     <addressUnitBits>8</addressUnitBits>
     <width>64</width>
+    <size>64</size>
     <peripherals>
         <peripheral>
             <name>peripheral1</name>
@@ -61,7 +62,7 @@
             <registers>
                 <register>
                     <!-- This register is actually an array of registers. -->
-                    <name>register1</name>
+                    <name>register[%s]</name>
                     <addressOffset>0x0</addressOffset>
                     <dim>2</dim>
                     <dimIncrement>0x40</dimIncrement>


### PR DESCRIPTION
I think it's not possible to determine the size of registers unless its specified at some level be it register or device. I added size to the device level. @RHamalainen do these changes match the designer's intent with these test cases?

Same for "[%s]": I don't think it's allowed to specify a dim-register without a template string.